### PR TITLE
Connects to #199 fix readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ See the Makefile in the [src/ontology](src/ontology) directory for the execution
 
 Each disease resource or ontology is pre-processed. In some cases, only a subset of the ontology is used
 
- * [ORDO/Orphanet](orphanet/README.md)
- * [DO](doid/README.md)
+ * ORDO/Orphanet
+ * DO
  * [GARD](gard/README.md) -- aligned as post-processing step
- * [OMIM](omim/README.md) -- note we only use labels from OMIM
- * [MedGeb](medgen/README.md) -- not yet incorporated
- * [NCIT](ncit/README.md) -- aligned as post-processing step
- * [OMIA](omia/README.md) -- Mendelian diseases in non-human animals
- * [MESH](medic/README.md) -- We use MEDIC as our initial pre-processed set
+ * OMIM -- note we only use labels from OMIM
+ * [MedGen](medgen/README.md) -- not yet incorporated
+ * NCIT -- aligned as post-processing step
+ * OMIA -- Mendelian diseases in non-human animals
+ * MESH -- We use MEDIC as our initial pre-processed set
  * [DiseaseClusters](clusters/README.md) -- Additional groupings of OMIM. Includes DECIPHER.
 
 ### Translating mappings to weighted candidate axioms

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Each disease resource or ontology is pre-processed. In some cases, only a subset
 
  * ORDO/Orphanet
  * DO
- * [GARD](gard/README.md) -- aligned as post-processing step
+ * [GARD](src/gard/README.md) -- aligned as post-processing step
  * OMIM -- note we only use labels from OMIM
- * [MedGen](medgen/README.md) -- not yet incorporated
+ * [MedGen](src/medgen/README.md) -- not yet incorporated
  * NCIT -- aligned as post-processing step
  * OMIA -- Mendelian diseases in non-human animals
  * MESH -- We use MEDIC as our initial pre-processed set

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Each disease resource or ontology is pre-processed. In some cases, only a subset
  * NCIT -- aligned as post-processing step
  * OMIA -- Mendelian diseases in non-human animals
  * MESH -- We use MEDIC as our initial pre-processed set
- * [DiseaseClusters](src/clusters/README.md) -- Additional groupings of OMIM. Includes DECIPHER.
+ * [DiseaseClusters](README-editors.md) -- Additional groupings of OMIM. Includes DECIPHER.
 
 ### Translating mappings to weighted candidate axioms
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Each disease resource or ontology is pre-processed. In some cases, only a subset
  * NCIT -- aligned as post-processing step
  * OMIA -- Mendelian diseases in non-human animals
  * MESH -- We use MEDIC as our initial pre-processed set
- * [DiseaseClusters](clusters/README.md) -- Additional groupings of OMIM. Includes DECIPHER.
+ * [DiseaseClusters](src/clusters/README.md) -- Additional groupings of OMIM. Includes DECIPHER.
 
 ### Translating mappings to weighted candidate axioms
 


### PR DESCRIPTION
Hopefully this is helpful, but feel free to close this PR and the relevant issue if these changes are not desired. I just noticed a few broken links when I looked at your repo today. I also fixed a typo for the MedGen link.

 - Inactive links (no README available) were removed. 
 - URLs corrected for other URLs - GARD, MedGeN, DiseaseClusters

_Note: I didn't know if DiseaseClusters should point to README-editors.md, but there was no file at clusters/README.md_